### PR TITLE
Bump to Python 3.8 and add environment variables for FeedbackFunction

### DIFF
--- a/backend/env.json
+++ b/backend/env.json
@@ -2,5 +2,10 @@
   "HasDogFunction": {
     "DOMAIN_NAME": "*",
     "ENVIRONMENT": "dev"
+  },
+  "FeedbackFunction": {
+    "DOMAIN_NAME": "*",
+    "ENVIRONMENT": "dev",
+    "BUCKET_NAME": "<Replace with Amazon S3 Bucket name>"
   }
 }

--- a/backend/template.yml
+++ b/backend/template.yml
@@ -12,7 +12,7 @@ Parameters:
 
 Globals:
   Function:
-    Runtime: python3.7
+    Runtime: python3.8
     Timeout: 30
     Environment:
       Variables:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Bump Lambda functions from Python 3.7 to Python 3.8
* Add environment variables for FeedbackFunction for local testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
